### PR TITLE
Updated sql dump giving error: Syntax error or access violation: 1067

### DIFF
--- a/lib/SQL-Storage-Boxx-0.sql
+++ b/lib/SQL-Storage-Boxx-0.sql
@@ -139,7 +139,7 @@ CREATE TABLE `purchases` (
   `p_email` varchar(255) NOT NULL,
   `p_address` varchar(255) NOT NULL,
   `p_notes` text DEFAULT NULL,
-  `p_date` date NOT NULL DEFAULT current_timestamp(),
+  `p_date` datetime NOT NULL DEFAULT current_timestamp(),
   `p_status` tinyint(1) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -190,7 +190,7 @@ CREATE TABLE `deliveries` (
   `d_email` varchar(255) NOT NULL,
   `d_address` varchar(255) NOT NULL,
   `d_notes` text DEFAULT NULL,
-  `d_date` date NOT NULL DEFAULT current_timestamp(),
+  `d_date` datetime NOT NULL DEFAULT current_timestamp(),
   `d_status` tinyint(1) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
Fix on sql dump with was giving the following errors on initial installation:

Unable to import SQL - SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'p_date'
Unable to import SQL - SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'd_date'

